### PR TITLE
Support for Python 3.7

### DIFF
--- a/SQream_python_connector.py
+++ b/SQream_python_connector.py
@@ -248,7 +248,7 @@ sqream_type_id =   {'ftBool':     'Bool',
                     }
 
 
-SqreamType = namedtuple('SqreamType', ['tid', 'size'], verbose=False)
+SqreamType = namedtuple('SqreamType', ['tid', 'size'])
 # tid is of type sqream_type_id, size is size of one item of this type
 
 class ColumnMetadata(object):


### PR DESCRIPTION
'Verbose' flag is not supported in Python 3.7, and it defaults to False anyway so it's not necessary